### PR TITLE
Commonize build file - 2

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -12,19 +12,6 @@
 
  <!-- Dependencies for this project -->
  <target name="setup:deps" depends="setup:deps:base">
-  <antcall target="setup:xsldoc"/>
- </target>
-
- <property name="dep.xsldoc.version" value="1.0.0"/>
-
- <target name="setup:xsldoc">
-  <property name="pkg" value="xsldoc-${dep.xsldoc.version}"/>
-  <property name="dir" value="${dir.work.xsl}/${pkg}"/>
-  <property name="url" value="https://github.com/xslet/xsldoc/archive/${dep.xsldoc.version}.zip"/>
-  <property name="zip" location="${dir.work.dl}/${pkg}.zip"/>
-  <property name="unzip" location="${dir}/.."/>
-  <get src="${url}" dest="${zip}"/>
-  <unzip src="${zip}" dest="${unzip}"/>
  </target>
 
 

--- a/res/ant/build.dependencies.xml
+++ b/res/ant/build.dependencies.xml
@@ -1,45 +1,58 @@
 <?xml version="1.0" encoding="utf-8"?>
 
 <project>
-
- <property name="dep.saxon.version"  value="11-2J"/>
- <property name="dep.tomcat.version" value="10.0.16"/>
-
-
  <import file="./build.directories.xml"/>
 
  <target name="setup:deps:base">
   <antcall target="setup:saxon"/>
   <antcall target="setup:tomcat"/>
+  <antcall target="setup:xsldoc"/>
  </target>
 
 
+ <property name="dep.saxon.version"  value="11-2J"/>
+ <property name="pkg.saxon" value="SaxonHE${dep.saxon.version}"/>
+ <property name="url.saxon" value="https://sourceforge.net/projects/saxon/files/Saxon-HE/11/Java/${pkg.saxon}.zip/download"/>
+ <property name="dir.saxon" value="${dir.work.lib}/${pkg.saxon}"/>
+
  <target name="setup:saxon">
-  <property name="pkg" value="SaxonHE${dep.saxon.version}"/>
-  <property name="url" value="https://sourceforge.net/projects/saxon/files/Saxon-HE/11/Java/${pkg}.zip/download"/>
-  <property name="dir" value="${dir.work.lib}/${pkg}"/>
-  <property name="zip" location="${dir.work.dl}/${pkg}.zip"/>
-  <property name="unzip" location="${dir}"/>
-  <get src="${url}" dest="${zip}"/>
+  <property name="zip" location="${dir.work.dl}/${pkg.saxon}.zip"/>
+  <property name="unzip" location="${dir.saxon}"/>
+  <get src="${url.saxon}" dest="${zip}"/>
   <unzip src="${zip}" dest="${unzip}"/>
  </target>
 
 
+ <property name="dep.tomcat.version" value="10.0.16"/>
  <property name="pkg.tomcat" value="apache-tomcat-${dep.tomcat.version}"/>
+ <property name="url.tomcat" value="https://archive.apache.org/dist/tomcat/tomcat-10/v${dep.tomcat.version}/bin/${pkg.tomcat}.zip"/>
  <property name="dir.tomcat" value="${dir.work.bin}/${pkg.tomcat}"/>
  <property name="dir.deploy" value="${dir.tomcat}/webapps/${ant.project.name}"/>
 
  <target name="setup:tomcat">
-  <property name="pkg" value="${pkg.tomcat}"/>
-  <property name="url" value="https://archive.apache.org/dist/tomcat/tomcat-10/v${dep.tomcat.version}/bin/${pkg}.zip"/>
-  <property name="dir" value="${dir.tomcat}"/>
-  <property name="zip" location="${dir.work.dl}/${pkg}.zip"/>
+  <property name="zip" location="${dir.work.dl}/${pkg.tomcat}.zip"/>
   <property name="unzip" location="${dir.work.bin}"/>
-  <get src="${url}" dest="${zip}"/>
+  <get src="${url.tomcat}" dest="${zip}"/>
   <unzip src="${zip}" dest="${unzip}"/>
-  <chmod perm="ugo+rx" dir="${dir}/bin" includes="**/*.sh"/>
+  <chmod perm="ugo+rx" dir="${dir.tomcat}/bin" includes="**/*.sh"/>
   <mkdir dir="${dir.deploy}"/>
  </target>
 
+
+ <condition property="is_xsldoc">
+  <equals arg1="${ant.project.name}" arg2="xsldoc"/>
+ </condition>
+
+ <property name="dep.xsldoc.version" value="1.0.0"/>
+ <property name="pkg.xsldoc" value="xsldoc-${dep.xsldoc.version}"/>
+ <property name="dir.xsldoc" value="${dir.work.lib}/${pkg.xsldoc}"/>
+ <property name="url.xsldoc" value="https://github.com/xslet/xsldoc/archive/${dep.xsldoc.version}.zip"/>
+
+ <target name="setup:xsldoc" unless="is_xsldoc">
+  <property name="zip" location="${dir.work.dl}/${pkg.xsldoc}.zip"/>
+  <property name="unzip" location="${dir.xsldoc}/.."/>
+  <get src="${url.xsldoc}" dest="${zip}"/>
+  <unzip src="${zip}" dest="${unzip}"/>
+ </target>
 
 </project>

--- a/res/ant/build.dependencies.xml
+++ b/res/ant/build.dependencies.xml
@@ -2,7 +2,7 @@
 
 <project>
 
- <property name="dep.saxon.version"  value="11-1J"/>
+ <property name="dep.saxon.version"  value="11-2J"/>
  <property name="dep.tomcat.version" value="10.0.16"/>
 
 

--- a/res/ant/build.targets.xml
+++ b/res/ant/build.targets.xml
@@ -148,22 +148,33 @@
 
  <target name="deploy"
    description="Deploy distributable files and test files to Tomcat.">
+  <antcall target="deploy:xsl:imported"/>
   <copy todir="${dir.docs.test}">
    <fileset dir="${dir.test}"/>
   </copy>
-  <copy todir="${dir.docs}/api/xsldoc">
-   <fileset dir="${dir.dist}"/>
-  </copy>
-  <copy todir="${dir.docs}/api/xsldoc" flatten="true">
-   <fileset dir="${dir.work.xsl}">
-    <include name="xsldoc-*/dist/*"/>
-   </fileset>
-  </copy>
-  <copy todir="${dir.docs}/test/unit">
+  <copy todir="${dir.docs.test}/unit">
    <fileset dir="${dir.res.doc}"/>
   </copy>
+  <copy todir="${dir.docs.api}/xsldoc">
+   <fileset dir="${dir.dist}"/>
+  </copy>
+  <antcall target="deploy:xsldoc"/>
   <copy todir="${dir.deploy}">
    <fileset dir="${dir.docs}"/>
+  </copy>
+ </target>
+
+ <target name="deploy:xsldoc" unless="is_xsldoc">
+  <copy todir="${dir.docs.api}/xsldoc">
+   <fileset dir="${dir.xsldoc}/dist"/>
+  </copy>
+ </target>
+
+ <target name="deploy:xsl:imported" unless="is_application">
+  <copy todir="${dir.test.unit}" flatten="true">
+   <fileset dir="${dir.work.xsl}">
+    <include name="*/dist/*.xsl"/>
+   </fileset>
   </copy>
  </target>
 


### PR DESCRIPTION
### Changes

1. Build: Upgrade a dependency Saxon to 11.2

    Because Saxon 11.2 was released on 18 February 2022.

2. Build: Move xsldoc setup to common, add deploy of imported xsl files and xsldoc files

    `setup:xsldoc` target was moved from `build.xml` to `res/ant/build.dependencies.xml` to commonize xsldoc setup for API document.
    To deploy imported XSL files to unit test directory was missing, so it is added.
    To deploy xsldoc files to api document directory was changed not to execute in xsldoc project.