### PR TITLE
Build: Add a target to copy dist files when xsldoc project to commonize build files

### DIFF
--- a/res/ant/build.targets.xml
+++ b/res/ant/build.targets.xml
@@ -155,13 +155,20 @@
   <copy todir="${dir.docs.test}/unit">
    <fileset dir="${dir.res.doc}"/>
   </copy>
-  <antcall target="deploy:xsldoc"/>
+  <antcall target="deploy:xsldoc:built"/>
+  <antcall target="deploy:xsldoc:dep"/>
   <copy todir="${dir.deploy}">
    <fileset dir="${dir.docs}"/>
   </copy>
  </target>
 
- <target name="deploy:xsldoc" unless="is_xsldoc">
+ <target name="deploy:xsldoc:built" if="is_xsldoc">
+  <copy todir="${dir.docs.api}/xsldoc">
+   <fileset dir="${dir.dist}"/>
+  </copy>
+ </target>
+
+ <target name="deploy:xsldoc:dep" unless="is_xsldoc">
   <copy todir="${dir.docs.api}/xsldoc">
    <fileset dir="${dir.xsldoc}/dist"/>
   </copy>


### PR DESCRIPTION
### Changed

A target to copy distribution files (`dist/*`) to the API document directory (`docs/api/xsldoc/`) when xsldoc project was missing. This PR adds this target for commonization of build files.